### PR TITLE
simplify this expression to use system properties

### DIFF
--- a/src/main/java/com/jackmeng/stl/stl0.java
+++ b/src/main/java/com/jackmeng/stl/stl0.java
@@ -12,9 +12,9 @@ final class stl0 {
         return Class.forName(str).getTypeParameters().length > 0;
     }
 
-    public static char dirm()
+    public static String dirm()
     {
-        return System.getProperty("os.name").toLowerCase().contains("wi") ? '\\' : '/';
+        return System.getProperty("file.separator");
     }
 
     public static boolean isGeneric(Class<?> e)


### PR DESCRIPTION
The previous implementation can be hidden away to another method, but this approach is much simpler and is less error prone due to the reliance on the runtime being correctly implemented.